### PR TITLE
Fix an incorrect module name cause node.js to fail.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,12 @@
 /* eslint no-console:0 */
 
 const d3 = require('d3-scale')
-const randomColor = require('randomColor')
+const randomcolor = require('randomcolor')
 
 var getColorScheme = function(count) {
     if (count <= 10) return d3.schemeCategory10;
     if (count <= 20) return d3.schemeCategory20;
-    return randomColor({ count: count })
+    return randomcolor({ count: count })
 }
 
 module.exports = {


### PR DESCRIPTION
randomcolor module was incorrectly imported in one of my older PR changes.